### PR TITLE
(remove): deprecated env

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,15 +4,6 @@
 resource "aws_s3_bucket" "this" {
   bucket = local.bucket_name
 
-  # Optional Object Lock Config
-  dynamic "object_lock_configuration" {
-    for_each = var.object_lock_rule != null ? [1] : []
-
-    content {
-      object_lock_enabled = "Enabled"
-    }
-  }
-
   force_destroy = var.force_s3_destroy
 
   tags = merge({


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket
NOTE on S3 Bucket Object Lock Configuration:
----
S3 Bucket Object Lock can be configured in either the standalone resource [aws_s3_bucket_object_lock_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) or with the deprecated parameter object_lock_configuration in the resource aws_s3_bucket. Configuring with both will cause inconsistencies and may overwrite configuration.