### PR TITLE
DTPK-122: fix kms_key_id for s3 object

### DIFF
--- a/folders.tf
+++ b/folders.tf
@@ -1,7 +1,7 @@
 resource "aws_s3_object" "this" {
   bucket                 = aws_s3_bucket.this.bucket
   key                    = "${var.folder_names[count.index]}/.keep"
-  kms_key_id             = var.is_use_kms_managed_key ? local.kms_key_id : null
+  kms_key_id             = var.is_use_kms_managed_key ? local.kms_key_arn : null
   server_side_encryption = var.is_use_kms_managed_key ? "aws:kms" : "AES256"
 
   tags = merge({


### PR DESCRIPTION
S3 object require KMS key ARN instead of KMS key ID.