### PR TITLE
fix: hardening policies ssl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this module will be documented in this file.
 
+## [v1.1.2] - 2022-07-27
+
+### Changed
+
+- In DenyNonSSLRequests, we update to `<s3_arn>` and `<s3_arn>/*` for best practice when hardening policies enable.
+
 ## [v1.1.1] - 2022-07-25
 
 ### Changed

--- a/bucket-policy.tf
+++ b/bucket-policy.tf
@@ -256,7 +256,7 @@ data "aws_iam_policy_document" "hardening" {
       "s3:*",
     ]
     effect    = "Deny"
-    resources = [aws_s3_bucket.this.arn]
+    resources = [aws_s3_bucket.this.arn, "${aws_s3_bucket.this.arn}/*"]
     condition {
       test     = "Bool"
       variable = "aws:SecureTransport"


### PR DESCRIPTION
## [v1.1.2] - 2022-07-27

### Changed

- In DenyNonSSLRequests, we update to `<s3_arn>` and `<s3_arn>/*` for best practice when hardening policies enable.