### PR TITLE
fix: provider version constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this module will be documented in this file.
 
+## [v2.0.1] - 2023-06-15
+
+### Changed
+
+- When running with a provider version of 6 or higher, certain modules may not function properly. However, we can address the modules that are not compatible with version 6 to ensure compatibility. This way, we don't need to edit all the modules. So we update the constraint to `>= 5.0.0` at the module level.
+- Update `module.bucket_kms_key` to use version `2.0.1`
+
 ## [v2.0.0] - 2023-06-08
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -96,21 +96,21 @@ module "server_log" {
 | Name                                                                      | Version  |
 |---------------------------------------------------------------------------|----------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 4.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random)          | >= 3.1.0 |
 
 ## Providers
 
 | Name                                                       | Version |
 |------------------------------------------------------------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws)          | 4.47.0  |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3   |
+| <a name="provider_aws"></a> [aws](#provider\_aws)          | 5.3.0   |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1   |
 
 ## Modules
 
 | Name                                                                               | Source            | Version |
 |------------------------------------------------------------------------------------|-------------------|---------|
-| <a name="module_bucket_kms_key"></a> [bucket\_kms\_key](#module\_bucket\_kms\_key) | oozou/kms-key/aws | 1.0.0   |
+| <a name="module_bucket_kms_key"></a> [bucket\_kms\_key](#module\_bucket\_kms\_key) | oozou/kms-key/aws | 2.0.1   |
 
 ## Resources
 

--- a/kms-key.tf
+++ b/kms-key.tf
@@ -1,6 +1,6 @@
 module "bucket_kms_key" {
   source  = "oozou/kms-key/aws"
-  version = "1.0.0"
+  version = "2.0.1"
 
   count = var.is_use_kms_managed_key && local.length_key_arn == 0 ? 1 : 0
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0, < 6.0.0"
+      version = ">= 5.0.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
# Submit a pull request :rocket:

Thank you for help us contribute! Please give us more information about this PR.

---

## What :kissing:

### Changed

- When running with a provider version of 6 or higher, certain modules may not function properly. However, we can address the modules that are not compatible with version 6 to ensure compatibility. This way, we don't need to edit all the modules. So we update the constraint to `>= 5.0.0` at the module level.
- Update `module.bucket_kms_key` to use version `2.0.1`

## Why :pleading_face:

- Simplify future upgrade